### PR TITLE
Bring README.md in line with GitLab

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,6 +1,7 @@
-<h1 align="center">Hi there 👋</h1>
+<div align="center">
+<h1>Hi there 👋</h1>
 
-<p align="center">
+<p>
   <a href="https://speechmatics.com">Homepage</a>
   <b> | </b><a href="https://www.speechmatics.com/about-us/company">About Us</a>
   <b> | </b><a href="https://www.speechmatics.com/about-us/careers">Careers</a>
@@ -11,20 +12,20 @@
   <b> | </b><a href="https://www.linkedin.com/company/speechmatics">LinkedIn</a>
 </p>
 
-<p align="center"><b><a href="https://page.speechmatics.com/free-trial.html">Start Free Trial 🚀</a></b></p>
+<p><b><a href="https://page.speechmatics.com/free-trial.html">Start Free Trial 🚀</a></b></p>
 
-<p align="center">
+<p>
   <b><a href="https://www.speechmatics.com/why-speechmatics">Why Choose Speechmatics?</a></b><br>
   We have a mindset that voice technology should be an accurate representation of the world around us. This has enabled us to build the most accurate and inclusive speech-to-text engine available.
 </p>
 
-<p align="center">
+<p>
   <b>Speechmatics ❤ Open Source</b>
   <br>
   <a href="https://github.com/speechmatics/speechmatics-python">speechmatics-python</a>, a Python client library and CLI for Speechmatics Realtime ASR v2 API <img src="https://github.com/speechmatics/speechmatics-python/workflows/Tests/badge.svg"</img><img src="https://codecov.io/gh/speechmatics/speechmatics-python/branch/master/graph/badge.svg"></img><img src=https://img.shields.io/badge/license-MIT-yellow.svg></img>
 </p>
 
-<p align="center">
+<p>
   <b>Some of our <a href="https://www.speechmatics.com/our-technology/research">research</a> 👩‍🔬</b>
   <br>
   <a href="https://arxiv.org/abs/2002.08111">Hierarchical Quantized Autoencoders</a> (code published in <a href="https://github.com/speechmatics/hqa">hqa repo</a>)
@@ -44,7 +45,7 @@
   <i>The first application of recurrent nets to speech recognition. A.J. Robinson and F. Fallside. Computer Speech and Language, 5(3):259–274, July 1991.</i>
 </p>
 
-<p align="center">
+<p>
   <b>Some of our <a href="https://medium.com/speechmatics">tech blogs</a> ✍</b>
   <br>
   <a href="https://medium.com/speechmatics/how-to-build-a-streaming-dataloader-with-pytorch-a66dd891d9dd">How to Build a Streaming DataLoader with PyTorch</a>
@@ -53,3 +54,4 @@
   <br>
   <a href="https://medium.com/speechmatics/how-to-write-kubernetes-custom-controllers-in-go-8014c4a04235">How to write Kubernetes custom controllers in Go</a>
 </p>
+</div>


### PR DESCRIPTION
GitLab doesn't allow us to align individual elements - it requires alignment on a div wrapping the rest.

This will bring the GitHub README in line with GitLab.